### PR TITLE
Separate app definition and controllers in examples

### DIFF
--- a/examples/crud/app.py
+++ b/examples/crud/app.py
@@ -3,18 +3,9 @@ import os
 
 from authentication import AuthenticationService
 from models import Product, User
-from vial.db.sql.postgresql import Postgresql
-from vial.server.application import Application
 
-engine = Postgresql(
-    dbname=os.getenv('POSTGRES_DATABASE'),
-    user=os.getenv('POSTGRES_USER'),
-    password=os.getenv('POSTGRES_PASSWORD'),
-    host=os.getenv('POSTGRES_HOST'),
-    port=os.getenv('POSTGRES_PORT')
-)
+from definition import app, engine
 
-app = Application('crud_example')
 app.define(models=[User, Product], engine=engine)
 
 

--- a/examples/crud/definition.py
+++ b/examples/crud/definition.py
@@ -1,0 +1,12 @@
+from vial.db.sql.postgresql import Postgresql
+from vial.server.application import Application
+
+app = Application('crud_example')
+
+engine = Postgresql(
+    dbname=os.getenv('POSTGRES_DATABASE'),
+    user=os.getenv('POSTGRES_USER'),
+    password=os.getenv('POSTGRES_PASSWORD'),
+    host=os.getenv('POSTGRES_HOST'),
+    port=os.getenv('POSTGRES_PORT')
+)

--- a/examples/helloworld/app.py
+++ b/examples/helloworld/app.py
@@ -1,6 +1,4 @@
-from vial.server.application import Application
-
-app = Application('helloworld')
+from definition import app
 
 
 @app.route(methods=['GET'], path='/$')

--- a/examples/helloworld/app.py
+++ b/examples/helloworld/app.py
@@ -1,4 +1,6 @@
-from definition import app
+from definition import app, engine
+
+app.define(models=[], engine=engine)
 
 
 @app.route(methods=['GET'], path='/$')

--- a/examples/helloworld/definition.py
+++ b/examples/helloworld/definition.py
@@ -1,0 +1,3 @@
+from vial.server.application import Application
+
+app = Application('helloworld')

--- a/examples/helloworld/definition.py
+++ b/examples/helloworld/definition.py
@@ -1,3 +1,8 @@
+from vial.db.sql.sqlite import Sqlite
 from vial.server.application import Application
 
 app = Application('helloworld')
+
+engine = Sqlite(
+    dbname='helloworld'
+)


### PR DESCRIPTION
Start off doing this with the examples to get an idea of what this would look like. Have to rethink how the `route` decorator works now that I know it's not possible to use the `app` directly through `definition` for initializing models/running the server because the controllers are defined in the other file after importing from the definition. Or maybe rethink what this separation looks like.